### PR TITLE
feat: add toString() to PartialValues

### DIFF
--- a/partialgen/src/main/java/com/xinto/partialgen/PartialValue.kt
+++ b/partialgen/src/main/java/com/xinto/partialgen/PartialValue.kt
@@ -8,9 +8,17 @@ import kotlinx.serialization.encoding.Encoder
 
 @Serializable(PartialValue.Serializer::class)
 sealed class PartialValue<out T> {
+    class Value<T>(val value: T) : PartialValue<T>() {
+        override fun toString(): String {
+            return value.toString()
+        }
+    }
 
-    class Value<T>(val value: T): PartialValue<T>()
-    class Missing<out T> : PartialValue<T>()
+    class Missing<out T> : PartialValue<T>() {
+        override fun toString(): String {
+            return "Missing"
+        }
+    }
 
     internal class Serializer<T>(
         private val valueSerializer: KSerializer<T>


### PR DESCRIPTION
The default Missing/Value toString make it impossible to debug partial objects