### PR TITLE
feat: add headers, cookies, OkHttp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         buildConfigField(
             "String",
             "URL_GATEWAY",
-            "\"wss://gateway.discord.gg/?v=9&encoding=json&compress=zlib-stream\""
+            "\"wss://gateway.discord.gg/?encoding=json&v=9&compress=zlib-stream\""
         )
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
             useSupportLibrary = true
         }
 
-        buildConfigField("int", "DISCORD_VERSION_CODE", "124012")
-        buildConfigField("String", "DISCORD_VERSION_NAME", "\"124.12 - Stable\"")
+        buildConfigField("int", "DISCORD_VERSION_CODE", "126021")
+        buildConfigField("String", "DISCORD_VERSION_NAME", "\"126.21 - Stable\"")
         buildConfigField("String", "URL_API", "\"https://discord.com/api/v9\"")
         buildConfigField("String", "URL_CDN", "\"https://cdn.discordapp.com\"")
         buildConfigField("String", "CAPTCHA_KEY", "\"f5561ba9-8f1e-40ca-9b5b-a0b3f719ef34\"")

--- a/app/src/main/java/com/xinto/opencord/di/HttpModule.kt
+++ b/app/src/main/java/com/xinto/opencord/di/HttpModule.kt
@@ -4,22 +4,27 @@ import com.xinto.opencord.BuildConfig
 import com.xinto.opencord.domain.manager.AccountManager
 import com.xinto.opencord.domain.provider.PropertyProvider
 import com.xinto.opencord.domain.provider.TelemetryProvider
-import com.xinto.opencord.util.Logger
 import io.ktor.client.*
 import io.ktor.client.engine.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.cookies.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.util.*
+import io.ktor.websocket.*
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+
+private typealias OCLogger = com.xinto.opencord.util.Logger
+private typealias KtorLogger = io.ktor.client.plugins.logging.Logger
 
 val HttpHeaders.XSuperProperties: String
     get() = "X-Super-Properties"
@@ -27,32 +32,56 @@ val HttpHeaders.XDiscordLocale: String
     get() = "X-Discord-Locale"
 
 val httpModule = module {
-
     fun provideJson(): Json {
         return Json {
             ignoreUnknownKeys = true
         }
     }
 
-    fun <T : HttpClientEngineConfig> HttpClientConfig<T>.installLogging(loggerDI: Logger) {
+    fun <T : HttpClientEngineConfig> HttpClientConfig<T>.installLogging(logger: OCLogger) {
+        if (!BuildConfig.DEBUG) return
+
         install(Logging) {
             level = LogLevel.BODY
-            logger = object : io.ktor.client.plugins.logging.Logger {
+            this.logger = object : KtorLogger {
                 override fun log(message: String) {
-                    loggerDI.debug("HTTP", message)
+                    logger.debug("HTTP", message)
                 }
             }
         }
     }
 
+    fun <T : HttpClientEngineConfig> HttpClientConfig<T>.installCookies() {
+        install(HttpCookies) {
+            // TODO: persist cookies to disk later
+            storage = AcceptAllCookiesStorage()
+        }
+    }
+
+    fun OkHttpConfig.addStripKtorHeadersInterceptor() {
+        addInterceptor { chain ->
+            val request = chain.request()
+            val requestBuilder = request
+                .newBuilder()
+                .removeHeader(HttpHeaders.Accept)
+                .removeHeader(HttpHeaders.AcceptCharset)
+
+            if (request.header(HttpHeaders.ContentType) == "application/json") {
+                requestBuilder.removeHeader(HttpHeaders.ContentType)
+            }
+
+            chain.proceed(requestBuilder.build())
+        }
+    }
+
     fun provideAuthClient(
         json: Json,
-        logger: Logger,
+        logger: OCLogger,
         telemetryProvider: TelemetryProvider,
         propertyProvider: PropertyProvider,
     ): HttpClient {
         val superProperties = json.encodeToString(propertyProvider.xSuperProperties).encodeBase64()
-        return HttpClient(CIO) {
+        return HttpClient(OkHttp) {
             defaultRequest {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 header(HttpHeaders.UserAgent, telemetryProvider.userAgent)
@@ -60,6 +89,7 @@ val httpModule = module {
                 header(HttpHeaders.XDiscordLocale, "en-US")
                 header(HttpHeaders.XSuperProperties, superProperties)
             }
+
             install(HttpRequestRetry) {
                 maxRetries = 5
                 retryIf { _, httpResponse ->
@@ -72,23 +102,31 @@ val httpModule = module {
                     retry * 1000L
                 }
             }
+
             install(ContentNegotiation) {
                 json(json)
             }
-            if (BuildConfig.DEBUG)
-                installLogging(logger)
+
+            installCookies()
+            installLogging(logger)
+
+            engine {
+                addStripKtorHeadersInterceptor()
+            }
         }
     }
 
     fun provideApiClient(
         json: Json,
-        logger: Logger,
+        logger: OCLogger,
         accountManager: AccountManager,
         telemetryProvider: TelemetryProvider,
         propertyProvider: PropertyProvider
     ): HttpClient {
-        val superProperties = json.encodeToString(propertyProvider.xSuperProperties).encodeBase64()
-        return HttpClient(CIO) {
+        return HttpClient(OkHttp) {
+            val superProperties =
+                json.encodeToString(propertyProvider.xSuperProperties).encodeBase64()
+
             defaultRequest {
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 header(HttpHeaders.Authorization, accountManager.currentAccountToken)
@@ -97,6 +135,7 @@ val httpModule = module {
                 header(HttpHeaders.XDiscordLocale, "en-US")
                 header(HttpHeaders.XSuperProperties, superProperties)
             }
+
             install(HttpRequestRetry) {
                 maxRetries = 5
                 retryIf { _, httpResponse ->
@@ -109,24 +148,58 @@ val httpModule = module {
                     retry * 2000L
                 }
             }
+
             install(ContentNegotiation) {
                 json(json)
             }
-            if (BuildConfig.DEBUG)
-                installLogging(logger)
-        }
-    }
 
-    fun provideGatewayClient(): HttpClient {
-        return HttpClient(CIO) {
-            install(WebSockets) {
-                maxFrameSize = Long.MAX_VALUE
+            installCookies()
+            installLogging(logger)
+
+            engine {
+                addStripKtorHeadersInterceptor()
             }
         }
     }
 
-    single { provideJson() }
+    fun provideGatewayClient(logger: OCLogger): HttpClient {
+        return HttpClient(OkHttp) {
+            defaultRequest {
+                header(HttpHeaders.AcceptEncoding, "gzip")
+                header(HttpHeaders.UserAgent, "okhttp/4.8.0")
+            }
+
+            install(WebSockets) {
+                maxFrameSize = Long.MAX_VALUE
+
+                extensions {
+                    install(WebSocketDeflateExtension) {
+                        compressIf { false }
+                        clientNoContextTakeOver = false
+                    }
+                }
+            }
+
+            install(HttpRequestRetry) {
+                maxRetries = 3
+                retryOnExceptionIf { _, error ->
+                    error is HttpRequestTimeoutException
+                }
+                delayMillis { retry ->
+                    retry * 2000L
+                }
+            }
+
+            installLogging(logger)
+
+            engine {
+                addStripKtorHeadersInterceptor()
+            }
+        }
+    }
+
+    singleOf(::provideJson)
     single(named("auth")) { provideAuthClient(get(), get(), get(), get()) }
     single(named("api")) { provideApiClient(get(), get(), get(), get(), get()) }
-    single(named("gateway")) { provideGatewayClient() }
+    single(named("gateway")) { provideGatewayClient(get()) }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,10 +4,10 @@ import org.gradle.kotlin.dsl.DependencyHandlerScope
 sealed class Dependencies {
 
     object Ktor : Dependencies() {
-        const val version = "2.0.3"
+        const val version = "2.1.3"
 
         const val ktorClientCore = "io.ktor:ktor-client-core:$version"
-        const val ktorClientCio = "io.ktor:ktor-client-cio:$version"
+        const val ktorClientOkHttp = "io.ktor:ktor-client-okhttp:$version"
         const val ktorClientWebsockets = "io.ktor:ktor-client-websockets:$version"
         const val ktorClientContentNegotiation = "io.ktor:ktor-client-content-negotiation:$version"
         const val ktorSerializationJson = "io.ktor:ktor-serialization-kotlinx-json:$version"
@@ -16,7 +16,7 @@ sealed class Dependencies {
         override fun invoke(scope: DependencyHandlerScope) {
             scope {
                 implementation(ktorClientCore)
-                implementation(ktorClientCio)
+                implementation(ktorClientOkHttp)
                 implementation(ktorClientWebsockets)
                 implementation(ktorClientContentNegotiation)
                 implementation(ktorSerializationJson)


### PR DESCRIPTION
- matches gateway & api headers now exactly
- store cf cookies in-memory for now
- use OkHttp (was already a transitive dependency + it has interceptors)